### PR TITLE
feat: support reexport of externals

### DIFF
--- a/examples/exports/index.html
+++ b/examples/exports/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/src/favicon.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Vite App</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script src="https://cdn.jsdelivr.net/npm/react@17.0.2/umd/react.development.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/react-dom@17.0.2/umd/react-dom.development.js"></script>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/examples/exports/package.json
+++ b/examples/exports/package.json
@@ -1,0 +1,22 @@
+{
+  "version": "0.0.0",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "serve": "vite preview"
+  },
+  "dependencies": {
+    "antd": "^4.16.11",
+    "less": "^4.1.1",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2"
+  },
+  "devDependencies": {
+    "@types/react": "^17.0.0",
+    "@types/react-dom": "^17.0.0",
+    "@vitejs/plugin-react-refresh": "^1.3.1",
+    "typescript": "^4.3.2",
+    "vite": "^2.3.7",
+    "vite-plugin-externals": "workspace:*"
+  }
+}

--- a/examples/exports/src/App.tsx
+++ b/examples/exports/src/App.tsx
@@ -1,0 +1,21 @@
+// eslint-disable-next-line no-use-before-define
+import React, { useState2, useEffect, ReactDom } from './exports'
+import 'antd/dist/antd.less'
+import { Button } from 'antd'
+
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+function App() {
+  const [count, setCount] = useState2(1)
+  useEffect(() => {
+    // eslint-disable-next-line no-console
+    console.log('ReactDom', ReactDom)
+  })
+
+  return (
+    <Button className="App" onClick={() => setCount(value => value + 1)}>
+      test externals ({count})
+    </Button>
+  )
+}
+
+export default App

--- a/examples/exports/src/exports.ts
+++ b/examples/exports/src/exports.ts
@@ -1,0 +1,2 @@
+export { default as ReactDom } from 'react-dom'
+export { default, useState as useState2, useEffect } from 'react'

--- a/examples/exports/src/main.tsx
+++ b/examples/exports/src/main.tsx
@@ -1,0 +1,11 @@
+// eslint-disable-next-line no-use-before-define
+import React from 'react'
+import ReactDOM from 'react-dom'
+import App from './App'
+
+ReactDOM.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+  document.getElementById('root'),
+)

--- a/examples/exports/src/vite-env.d.ts
+++ b/examples/exports/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/examples/exports/tsconfig.json
+++ b/examples/exports/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": false,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react"
+  },
+  "include": ["./src"]
+}

--- a/examples/exports/vite.config.ts
+++ b/examples/exports/vite.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from 'vite'
+import reactRefresh from '@vitejs/plugin-react-refresh'
+import { viteExternalsPlugin } from 'vite-plugin-externals'
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  plugins: [
+    reactRefresh(),
+    viteExternalsPlugin({
+      react: 'React',
+      'react-dom': 'ReactDOM',
+    }),
+  ],
+  css: {
+    preprocessorOptions: {
+      less: {
+        // 允许链式调用的换行
+        javascriptEnabled: true,
+      },
+    },
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,31 @@ importers:
       typescript: 4.3.2
       vite: 2.3.7
 
+  examples/exports:
+    specifiers:
+      '@types/react': ^17.0.0
+      '@types/react-dom': ^17.0.0
+      '@vitejs/plugin-react-refresh': ^1.3.1
+      antd: ^4.16.11
+      less: ^4.1.1
+      react: ^17.0.2
+      react-dom: ^17.0.2
+      typescript: ^4.3.2
+      vite: ^2.3.7
+      vite-plugin-externals: workspace:*
+    dependencies:
+      antd: 4.16.11_react-dom@17.0.2+react@17.0.2
+      less: 4.1.1
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+    devDependencies:
+      '@types/react': 17.0.11
+      '@types/react-dom': 17.0.7
+      '@vitejs/plugin-react-refresh': 1.3.3
+      typescript: 4.3.2
+      vite: 2.3.7
+      vite-plugin-externals: link:../..
+
   examples/react-ts:
     specifiers:
       '@types/react': ^17.0.0


### PR DESCRIPTION
Some source code can create files that re-export external dependencies

This PR will add support for such use cases.

I've also added a new `examples/exports` to make sure it works

Examples of transformations:

```typescript
// src/exports.ts
// source
export { default, default as renamedDefault, useState, useEffect as renamedUseEffect } from 'react'
// transformed
export default = window['React']
export const renamedDefault = window['React']
export const useState = window['React'].useState
export const renamedUseEffect = window['React'].useEffect
```

Fixes #9 