### PR TITLE
fix: process mjs files

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ type Specifiers = (ESTree.ImportSpecifier | ESTree.ImportDefaultSpecifier | ESTr
 type TransformModuleNameFn = (externalValue: ExternalValue) => string
 
 // constants
-const ID_FILTER_REG = /\.(js|ts|vue|jsx|tsx)$/
+const ID_FILTER_REG = /\.(mjs|js|ts|vue|jsx|tsx)(\?.*|)$/
 const NODE_MODULES_FLAG = 'node_modules'
 const CACHE_DIR = '.vite-plugin-externals'
 


### PR DESCRIPTION
Add support for `mjs` files that could existed on bundled
node_modules
Also I had an issue where files like the following were
not processed:
`node_modules/.pnpm/react@16.14.0/node_modules/react/jsx-runtime.js?commonjs-module`

By updating the regex to optionnaly support `?.*$`, it now works fine