### PR TITLE
fix: return partial config from vite config hook

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -74,12 +74,11 @@ export function viteExternalsPlugin(externals: Externals = {}, userOptions: User
         )
       }
 
-      config.resolve = {
-        ...(config.resolve ?? {}),
-        alias: newAlias,
+      return {
+        resolve: {
+          alias: newAlias,
+        },
       }
-
-      return config
     },
     async transform(code, id, _options) {
       const ssr = compatSsrInOptions(_options)


### PR DESCRIPTION
Because vite deeply merges configs, returning the entire config from the config hook should be avoided. Instead return the partial config with alias entries.

Reference: https://vitejs.dev/guide/api-plugin.html#config