### PR TITLE
fix: types export

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,1 +1,1 @@
-export * from './dist'
+export * from './dist/src'


### PR DESCRIPTION
fixes types export. Seems like new correct destination is dist/src.